### PR TITLE
Add Build instructions and built.bat script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,3 +402,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+.idea

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,54 @@
+# How to build?
+
+## Requirements
+
+To build XeUnshackle, you need a development environment on Windows, with:
+* Visual Studio 2010
+  * VS 2010 Professional ([installer here](https://archive.org/details/en_visual_studio_2010_professional_x86_dvd_509727)), install at minimum these features:
+    * Visual C++
+    * Visual C#
+    * Graphics Library
+  * VS 2010 SP1 ([installer here](https://archive.org/details/vs-2010-sp-1dvd-1))
+* Install Xbox 360 SDK
+  * Use `XDKSetupXenon21256.3.exe` or `XDKSetupXenon21256.17.exe`, choose Full install
+  * Install this **after** VS 2010 and VS 2010 SP1
+* Visual Studio 2019 ([installer here](https://archive.org/download/vs_community__e8aae2bc1239469a8cb34a7eeb742747/vs_community_2019.exe)) or Visual Studio 2022
+
+## Build in IDE
+
+### VS 2019
+Open the [`XeUnshackle.sln`](XeUnshackle.sln) file and Build Solution (F7).
+
+### VS 2022
+When you run Buld Solution in VS 2022, it will fail on this error:
+```
+...
+error MSB4062: The "CL" task could not be loaded from the assembly C:\Program Files (x86)\Microsoft Xbox 360 SDK\bin\win32\Microsoft.Xna.Xbox360.Build.dll
+...
+An attempt was made to load a program with an incorrect format.
+...
+```
+
+The build fails because Visual Studio 2022 is a 64-bit application, while the old Xbox 360 XDK and its build tools (like Microsoft.Xna.Xbox360.Build.dll) are 32-bit. A 64-bit process cannot load 32-bit DLLs, which causes the "incorrect format" error. Visual Studio 2019 and all prior versions are 32-bit applications, so they are compatible with the 32-bit XDK toolchain.
+
+To work around this issue, you can use a custom [`build.bat`](build.bat) script to build using the 32-bit MSBuild. You can run the [`build.bat`](build.bat) file directly from Visual Studio's Tools menu. This lets you trigger custom build process with a single click. Here’s how to set it up:
+
+1. VS 2022 > `Tools` > `External Tools...` > `Add`
+2. Fill in the field as follows:
+   * Title: `Build Solution 32-bit`
+   * Command: `cmd.exe`
+   * Arguments: `/c "$(SolutionDir)build.bat"`
+   * Initial directory: `$(SolutionDir)`
+3. Check the `Use Output window` box. This is important because it will show the script's output directly in Visual Studio's `Output` panel, so you can see the build progress and any errors.
+4. Click OK
+
+To run it simply click `Tools` > `Build Solution 32-bit`, the output will appear in the `Output` window (you may need to change the `Show output from:` dropdown to `Build Solution 32-bit`).
+
+### JetBrains Rider
+
+[Rider](https://www.jetbrains.com/rider/) allows to select a custom version of MSBuild, so the setup is much easier than VS 2022 and fully integrated into the IDE.
+
+1. Open the [`XeUnshackle.sln`](XeUnshackle.sln) file.
+2. Open `Settings` > `Build, Execution, Deployment` > `Toolset and Build` and click on `Custom...` next to `MSBuild version`
+3. Select the 32-bit `Bin\MSBuild.exe` of your installed modern VS (2019+). Note this must **not** be `Bin\amd64\MSBuild.exe` as that would be the incompatible 64-bit version. Example of the correct path: `C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe`
+4. Build Solution (Ctrl+F9)

--- a/README.md
+++ b/README.md
@@ -57,3 +57,6 @@ Any files saved/dumped can be found in the BadUpdatePayload folder of the usb.
 ## Community Translations
 - Spanish - [CiberStore](https://github.com/CiberStore)
 - Portuguese (Brazil) - [ronniegchagas](https://github.com/ronniegchagas)
+
+## Build instructions
+See [BUILD.md](BUILD.md)

--- a/XeUnshackle.vcxproj
+++ b/XeUnshackle.vcxproj
@@ -60,7 +60,10 @@
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <None Include="BUILD.md" />
+    <None Include="README.md" />
     <None Include="ReadMe.txt" />
+    <None Include="build.bat" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Dashlaunch.h" />

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,59 @@
+@echo off
+setlocal
+
+:: ============================================================================
+:: Build Script for XeUnshackle.sln using the latest 32-bit MSBuild
+:: ============================================================================
+:: This script automatically finds the latest 32-bit MSBuild.exe from any
+:: modern Visual Studio installation and uses it to build the solution.
+:: ============================================================================
+
+echo Searching for the latest 32-bit MSBuild.exe...
+
+set "VSWHERE_PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+
+:: First, check if vswhere.exe even exists to provide a better error message.
+if not exist "%VSWHERE_PATH%" (
+    echo ERROR: Cannot find vswhere.exe at "%VSWHERE_PATH%".
+    echo Please ensure Visual Studio 2019 or newer is installed.
+    echo.
+    pause
+    exit /b 1
+)
+
+:: Variable to hold the final path to MSBuild.exe
+set "MSBUILD_EXE="
+
+:: Execute the vswhere command and capture its output into the MSBUILD_EXE variable
+:: The 'if not defined' ensures we only take the first line of output if multiple are returned.
+for /f "usebackq tokens=*" %%i in (`"%VSWHERE_PATH%" -latest -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
+    if not defined MSBUILD_EXE set "MSBUILD_EXE=%%i"
+)
+
+if not defined MSBUILD_EXE (
+    echo ERROR: Could not find a 32-bit MSBuild.exe path.
+    :: The parentheses in the next line are "escaped" with ^ to prevent a syntax error.
+    echo Please ensure a recent version of Visual Studio ^(2019, 2022^) or its Build Tools are installed correctly.
+    echo.
+    pause
+    exit /b 1
+)
+
+echo Found 32-bit MSBuild at: %MSBUILD_EXE%
+echo.
+echo ============================================================================
+echo Starting build...
+echo Solution: XeUnshackle.sln
+echo Configuration: Release_LTCG
+echo Platform: Xbox 360
+echo ============================================================================
+echo.
+
+:: Execute MSBuild with the specified solution and parameters.
+"%MSBUILD_EXE%" XeUnshackle.sln /p:Configuration=Release_LTCG /p:Platform="Xbox 360"
+
+echo.
+echo ============================================================================
+echo Build process finished.
+echo ============================================================================
+endlocal


### PR DESCRIPTION
This PR adds Build instructions file and `built.bat` script for finding 32-bit MSBuild and using it to build project solution.

Instructions cover required software, and these IDEs: VS2019, VS2022, JetBrains Rider.

Fixes #16